### PR TITLE
Exclude @Exclude properties from output rather than set them to null

### DIFF
--- a/src/decorators/Exclude.ts
+++ b/src/decorators/Exclude.ts
@@ -1,7 +1,7 @@
-import {OnDehydrateMetadataKey, OnDehydrateMetadata} from './OnDehydrate';
+export const ExcludeMetadataKey = "EXCLUDE";
+
+class ExcludeMetadata { }
 
 export function Exclude(){
-  let newMetadata = new OnDehydrateMetadata(()=>null);
-
-  return Reflect.metadata(OnDehydrateMetadataKey, newMetadata);
+  return Reflect.metadata(ExcludeMetadataKey, new ExcludeMetadata());
 }

--- a/src/specs/Hydrator.spec.ts
+++ b/src/specs/Hydrator.spec.ts
@@ -170,10 +170,10 @@ describe("Exclude", function(){
     let child = new Child('child', 12);
     let dehydratedChild = dehydrate(child);
     it("should work on own property", function(){
-      expect(dehydratedChild.age).toBeNull();
+      expect(dehydratedChild.age).toBeUndefined();
     });
     it("should work on inherited property", function(){
-      expect(dehydratedChild.name).toBeNull();
+      expect(dehydratedChild.name).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
#1 

I noticed that entirely excluding properties decorated with `@Exclude`  breaks the `both Exclude and OnHydrate` tests as there is no property to trigger the `OnHydrate` call.

```
  class Child extends Parent{
    @Exclude()
    @OnHydrate(()=>"Child.OnHydrate applied")
    age:number;
    constructor(name, age){ super(name); this.age = age;}
  }
```

The main issue I had with the existing functionality is that excluded properties get overwritten with nulls I deserialise. 